### PR TITLE
[lutram-tests/jtag-test] Fix RAM32M/RAM64M INIT assignment; Return values from read_lutram/write_lutram/read_lutram_range

### DIFF
--- a/lutram-tests/jtag-test/README.md
+++ b/lutram-tests/jtag-test/README.md
@@ -111,7 +111,7 @@ Open On-Chip Debugger
 [`setup.cfg`](./setup.cfg) defines the following commands for reading from or writing to LUTRAM:
 
 - `read_lutram <address>` : read data in hex from LUTRAM at `address`
-- `read_lutram_range <start_address> <count>` : read data in hex from LUTRAM starting from `start` to `start + count` (exclusive)
+- `read_lutram_range <start> <count>` : read data in hex from LUTRAM starting from `start` to `start + count` (exclusive)
 - `write_lutram <address> <data>` : write `data` to LUTRAM at `address`
 
 ## License

--- a/lutram-tests/jtag-test/README.md
+++ b/lutram-tests/jtag-test/README.md
@@ -110,8 +110,8 @@ Open On-Chip Debugger
 
 [`setup.cfg`](./setup.cfg) defines the following commands for reading from or writing to LUTRAM:
 
-- `read_lutram <address>` : read data in hex from LUTRAM at `address`
-- `read_lutram_range <start> <count>` : read data in hex from LUTRAM starting from `start` to `start + count` (exclusive)
+- `read_lutram <address>` : read and return data in hex from LUTRAM at `address`
+- `read_lutram_range <start> <count>` : read data in hex from LUTRAM starting from `start` to `start + count` (exclusive); return array of data values
 - `write_lutram <address> <data>` : write `data` to LUTRAM at `address`
 
 ## License

--- a/lutram-tests/jtag-test/lutram_inst.vh
+++ b/lutram-tests/jtag-test/lutram_inst.vh
@@ -269,10 +269,10 @@
 `endif
     RAM32M #(
         .IS_WCLK_INVERTED(1'b0),
-        .INIT_A(INIT[31:0]),
-        .INIT_B(INIT[63:32]),
-        .INIT_C(INIT[95:64]),
-        .INIT_D(INIT[127:96])
+        .INIT_D(INIT[63:0]),
+        .INIT_C(INIT[127:64]),
+        .INIT_B(INIT[191:128]),
+        .INIT_A(INIT[255:192])
     ) ram32m (
         .WCLK(jtag_drck),
         .WE(lutram_we),
@@ -298,10 +298,10 @@
 `endif
     RAM64M #(
         .IS_WCLK_INVERTED(1'b0),
-        .INIT_A(INIT[63:0]),
-        .INIT_B(INIT[127:64]),
-        .INIT_C(INIT[191:128]),
-        .INIT_D(INIT[255:192])
+        .INIT_D(INIT[63:0]),
+        .INIT_C(INIT[127:64]),
+        .INIT_B(INIT[191:128]),
+        .INIT_A(INIT[255:192])
     ) ram64m (
         .WCLK(jtag_drck),
         .WE(lutram_we),

--- a/lutram-tests/jtag-test/setup.cfg
+++ b/lutram-tests/jtag-test/setup.cfg
@@ -10,9 +10,10 @@ set user3_width 18
 set user4_instr 0x23
 set user4_width 16
 
-# Read and print data from LUTRAM at given address
+# Read and return data from LUTRAM at given address
 # Arg:
 #  - address: 8-bit address
+# Returns 8-bit data
 proc read_lutram {address} {
     global user3_instr
     global user3_width
@@ -26,13 +27,15 @@ proc read_lutram {address} {
     # Read reply while USER4 is loaded
     irscan xc7.tap $user4_instr
     set ret [string cat 0x [drscan xc7.tap $user4_width 0]]
-    echo [format 0x%x [expr {$ret >> 8}]]
+    set ret [expr {$ret >> 8}]
+    return [format 0x%x $ret]
 }
 
 # Write data to LUTRAM at given address
 # Args:
 #  - address: 8-bit address
 #  - data: 8-bit data
+# Returns 0 on completion
 proc write_lutram {address data} {
     global user3_instr
     global user3_width
@@ -47,18 +50,20 @@ proc write_lutram {address data} {
     # Read reply while USER4 is loaded to perform write by toggling LUTRAM WCLK
     irscan xc7.tap $user4_instr
     drscan xc7.tap $user4_width 0
-    echo 1
+    return 0
 }
 
 # Read from LUTRAM from start to start+count (exclusive)
 # Args:
 #  - start: starting 8-bit address
 #  - count: number of read operations
+# Returns 0 on completion
 proc read_lutram_range {start count} {
     set end [expr {$start + $count}]
     for {set x $start} {$x < $end} {set x [expr {$x + 1}]} {
-        read_lutram $x
+        echo [format 0x%x [read_lutram $x]]
     }
+    return 0
 }
 
 echo "setup.cfg loaded"

--- a/lutram-tests/jtag-test/setup.cfg
+++ b/lutram-tests/jtag-test/setup.cfg
@@ -61,4 +61,4 @@ proc read_lutram_range {start count} {
     }
 }
 
-echo "openocd.cfg loaded"
+echo "setup.cfg loaded"

--- a/lutram-tests/jtag-test/setup.cfg
+++ b/lutram-tests/jtag-test/setup.cfg
@@ -57,13 +57,16 @@ proc write_lutram {address data} {
 # Args:
 #  - start: starting 8-bit address
 #  - count: number of read operations
-# Returns 0 on completion
+# Returns array (index value)
 proc read_lutram_range {start count} {
+    array set arr {}
+    set start [expr {$start & 0xff}]
     set end [expr {$start + $count}]
     for {set x $start} {$x < $end} {set x [expr {$x + 1}]} {
-        echo [format 0x%x [read_lutram $x]]
+        set arr($x) [read_lutram $x]
+        echo [format 0x%x $arr($x)]
     }
-    return 0
+    return $arr
 }
 
 echo "setup.cfg loaded"


### PR DESCRIPTION
This PR does the following:
- Fixes RAM32M INIT_{A:D} assignments to be 64-bits (not 32).
- Reverses RAM32M/RAM64M INIT_{A:D} mapping to the 256-bit INIT pattern such that INIT_D maps to INIT[63:0], INIT_C maps to INIT[127:64], and so on.
- Makes functions defined in setup.cfg return values or success (0) for improved scripting.