### PR TITLE
lutram-tests/jtag-test: Add LUTRAM INIT openocd tests

### DIFF
--- a/lutram-tests/jtag-test/README.md
+++ b/lutram-tests/jtag-test/README.md
@@ -140,7 +140,7 @@ Open On-Chip Debugger
 [`setup.cfg`](./setup.cfg) defines the following commands for reading from or writing to LUTRAM:
 
 - `read_lutram <address>` : read and return data in hex from LUTRAM at `address`
-- `read_lutram_range <start> <count>` : read data in hex from LUTRAM starting from `start` to `start + count` (exclusive); return array of data values
+- `read_lutram_range <start> <count>` : read data in hex from LUTRAM starting from `start` to `start + count` (exclusive); return list of data values
 - `write_lutram <address> <data>` : write `data` to LUTRAM at `address`
 
 ## License

--- a/lutram-tests/jtag-test/README.md
+++ b/lutram-tests/jtag-test/README.md
@@ -12,6 +12,7 @@ This test is intended to validate functional aspects of LUT_OR_MEM BELs over JTA
 
 - [ ] Generate test input vectors (as openocd commands)
 - [ ] Generate expected output given type of LUTRAM and test input
+- [ ] Generate INIT pattern
 
 ## Default FPGA Target
 
@@ -142,6 +143,32 @@ Open On-Chip Debugger
 - `read_lutram <address>` : read and return data in hex from LUTRAM at `address`
 - `read_lutram_range <start> <count>` : read data in hex from LUTRAM starting from `start` to `start + count` (exclusive); return list of data values
 - `write_lutram <address> <data>` : write `data` to LUTRAM at `address`
+
+## Testing LUTRAM INIT with OpenOCD
+
+First build and program FPGA target with LUTRAM to test.
+
+To test if LUTRAM is initialized correctly, run the following:
+
+```
+openocd -f interface/ADAPTER.cfg -f ./tests.cfg -c "print_test_result [test_<LUTRAM_TYPE>_init]" -c "shutdown"
+```
+
+Available `LUTRAM_TYPE` options:
+
+- RAMS32
+- RAMD32
+- RAMS64E
+- RAMD64E
+- RAM32X1S
+- RAM64X1S
+- RAM128X1S
+- RAM256X1S
+- RAM32X1D
+- RAM64X1D
+- RAM128X1D
+- RAM32M
+- RAM64M
 
 ## License
 

--- a/lutram-tests/jtag-test/README.md
+++ b/lutram-tests/jtag-test/README.md
@@ -46,7 +46,7 @@ make FAMILY=kintex7 PART=xc7k325tffg900-2 BOARD=kc705 JTAG_CABLE=digilent ...
 To generate the bitstream with a specified LUTRAM cell using the Vivado toolchain, run the following:
 
 ```
-make [PART=...] [XDC=...] LUTRAM=<LUTRAM_TYPE> clean top.vivado.bit
+make [PART=...] [XDC=...] LUTRAM=<LUTRAM_TYPE> vivadoclean top.vivado.bit
 ```
 
 Available `LUTRAM_TYPE` options:

--- a/lutram-tests/jtag-test/init.cfg
+++ b/lutram-tests/jtag-test/init.cfg
@@ -1,0 +1,3 @@
+# TODO: generate me
+# INIT split into list of 32-bit values starting with INIT[31:0]
+set lutram_init_list [list 0x76543210 0xFEDCBA98 0x89ABCDEF 0x01234567 0x0F0FFFFF 0xCAFEF00D 0x0150BAD0 0xDEADBEEF]

--- a/lutram-tests/jtag-test/setup.cfg
+++ b/lutram-tests/jtag-test/setup.cfg
@@ -57,16 +57,15 @@ proc write_lutram {address data} {
 # Args:
 #  - start: starting 8-bit address
 #  - count: number of read operations
-# Returns array (index value)
+# Returns list of values
 proc read_lutram_range {start count} {
-    array set arr {}
+    set ret {}
     set start [expr {$start & 0xff}]
     set end [expr {$start + $count}]
     for {set x $start} {$x < $end} {set x [expr {$x + 1}]} {
-        set arr($x) [read_lutram $x]
-        echo [format 0x%x $arr($x)]
+        lappend ret [read_lutram $x]
     }
-    return $arr
+    return $ret
 }
 
 echo "setup.cfg loaded"

--- a/lutram-tests/jtag-test/tests.cfg
+++ b/lutram-tests/jtag-test/tests.cfg
@@ -1,0 +1,183 @@
+source ./setup.cfg
+source ./init.cfg
+
+# LUTRAM Tests
+
+# Extract n-th bit from num
+proc bit_extract {num n} {
+    return [expr {($num >> $n) & 0x1}]
+}
+
+# Deinterleaves two n-bit integer values a and b, starting with a
+# Args:
+#  - n: bit length of a and b
+#  - a: first interleaved integer component
+#  - b: second interleaved integer component
+# Returns (n*2)-bit deinterleaved number
+proc deinterleave_bits {n a b} {
+    set ret 0
+    for {set i 0} {$i < $n} {set i [expr {$i + 1}]} {
+        set ret [expr {([bit_extract $b $i] << ($i*2 + 1)) | ([bit_extract $a $i] << ($i*2)) | $ret}]
+    }
+    return $ret
+}
+
+# Extracts n-th bit of each sample in the list
+# Args:
+#  - list: list of samples
+#  - n: n-th bit to extract from a sample
+# Returns a list of extracted 1-bit values
+proc bits_mux {list n} {
+    set ret {}
+    foreach sample $list {
+        lappend ret [bit_extract $sample $n]
+    }
+    return $ret
+}
+
+# Assemble a number from bit_list such that n-th bit of the number maps to
+# n-th entry in bit_list
+# Args:
+#  - bit_list: list of 1-bit samples; length of list cannot exceed 64-bits.
+# Returns a number created from bit_list
+proc assemble_from_bit_list {bit_list} {
+    set ret 0
+    for {set i 0} {$i < [llength $bit_list]} {set i [expr {$i + 1}]} {
+        set ret [expr {([lindex $bit_list $i] << $i) | $ret}]
+    }
+    return $ret
+}
+
+# Prints test results of each output data port
+proc print_test_result {result_list} {
+    for {set i 0} {$i < [llength $result_list]} {set i [expr {$i + 1}]} {
+        echo "lutram_do\[$i\]: [lindex $result_list $i]"
+    }
+}
+
+# LUTRAM INIT Tests
+
+# Checks INIT pattern of single- or dual-read-port LUTRAM
+# Arg:
+#  - n: bit length of LUTRAM's INIT pattern (as multiple of 32)
+#  - num_outputs: 1 or 2
+proc test_lutram_init {n num_outputs} {
+    global lutram_init_list
+    set result {}
+    for {set i 0} {$i < $num_outputs} {set i [expr {$i + 1}]} {
+        lappend result PASS
+    }
+    # compare 32-bits at a time
+    set end [expr {$n / 32}]
+    for {set i 0} {$i < $end} {set i [expr {$i + 1}]} {
+        # INIT[i*32-1:i*32]
+        set init32_pattern [lindex $lutram_init_list $i]
+        set addr [expr {$i * 32}]
+        set samples [read_lutram_range $addr 32]
+        for {set port 0} {$port < $num_outputs} {set port [expr {$port + 1}]} {
+            set lutram_pattern [assemble_from_bit_list [bits_mux $samples $port]]
+            if {$init32_pattern != $lutram_pattern} {
+                echo "port $port: got [format 0x%x $lutram_pattern] but expected [format 0x%x $init32_pattern]"
+                lset result $port FAIL
+            }
+        }
+    }
+    return $result
+}
+
+proc test_RAMS32_init {} {
+    return [test_lutram_init 32 1]
+}
+
+proc test_RAMD32_init {} {
+    # RADR=WADR
+    return [test_RAMS32_init]
+}
+
+proc test_RAM32X1S_init {} {
+    return [test_RAMS32_init]
+}
+
+proc test_RAM32X1D_init {} {
+    # RADR=WADR
+    return [test_lutram_init 32 2]
+}
+
+proc test_RAMS64E_init {} {
+    return [test_lutram_init 64 1]
+}
+
+proc test_RAM64X1S_init {} {
+    return [test_RAMS64E_init]
+}
+
+proc test_RAM64X1D_init {} {
+    # RADR=WADR
+    return [test_lutram_init 64 2]
+}
+
+proc test_RAM128X1S_init {} {
+    return [test_lutram_init 128 1]
+}
+
+proc test_RAM128X1D_init {} {
+    # RADR=WADR
+    return [test_lutram_init 128 2]
+}
+
+proc test_RAM256X1S_init {} {
+    return [test_lutram_init 256 1]
+}
+
+proc test_RAM32M_init {} {
+    global lutram_init_list
+    set result {PASS PASS PASS PASS PASS PASS PASS PASS}
+    # compare 32-bits at a time
+    for {set i 0} {$i < 2} {set i [expr {$i + 1}]} {
+        set addr [expr {$i * 16}]
+        set samples [read_lutram_range $addr 16]
+        # For each port group
+        for {set port_group 0} {$port_group < 4} {set port_group [expr {$port_group + 1}]} {
+            set offset [expr {$port_group * 64}]
+            # INIT[i*32 + offset - 1:i*32 + offset]
+            set init_index [expr {($offset / 32) + $i}]
+            set init32_pattern [lindex $lutram_init_list $init_index]
+
+            set lower16_pattern [assemble_from_bit_list [bits_mux $samples [expr {$port_group*2}]]]
+            set upper16_pattern [assemble_from_bit_list [bits_mux $samples [expr {$port_group*2+1}]]]
+            set lutram32_pattern [deinterleave_bits 16 $lower16_pattern $upper16_pattern]
+            if {$init32_pattern != $lutram32_pattern} {
+                echo "port group $port_group: got [format 0x%x $lutram32_pattern] but expected [format 0x%x $init32_pattern]"
+                lset result [expr {$port_group*2}] FAIL
+                lset result [expr {$port_group*2+1}] FAIL
+            }
+        }
+    }
+    return $result
+}
+
+proc test_RAM64M_init {} {
+    global lutram_init_list
+    set result {PASS PASS PASS PASS}
+    # compare 32-bits at a time
+    for {set i 0} {$i < 2} {set i [expr {$i + 1}]} {
+        set addr [expr {$i * 32}]
+        set samples [read_lutram_range $addr 32]
+        # For each port group
+        for {set port_group 0} {$port_group < 4} {set port_group [expr {$port_group + 1}]} {
+            set offset [expr {$port_group * 64}]
+            # INIT[i*32 + offset - 1:i*32 + offset]
+            set init_index [expr {($offset / 32) + $i}]
+            set init32_pattern [lindex $lutram_init_list $init_index]
+
+            set lutram_pattern [assemble_from_bit_list [bits_mux $samples $port_group]]
+            if {$init32_pattern != $lutram_pattern} {
+                echo "port group $port_group: got [format 0x%x $lutram_pattern] but expected [format 0x%x $init32_pattern]"
+                lset result $port_group FAIL
+            }
+        }
+    }
+    return $result
+}
+
+echo "tests.cfg loaded"


### PR DESCRIPTION
This PR introduces `tests.cfg` with openocd test functions to validate whether LUTRAM is initialized correctly (assuming the user did not overwrite contents of LUTRAM).

For example, if I have a bitstream with RAM32M freshly loaded onto the FPGA, I can test RAM32M by running the following:

```
$ openocd -f digilent-hs2.cfg -f tests.cfg -c "print_test_result [test_RAM32M_init]" -c "shutdown"
Open On-Chip Debugger 0.12.0
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "jtag". To override use 'transport select <transport>'.
Info : clock speed 1 kHz
Info : JTAG tap: xc7.tap tap/device found: 0x13636093 (mfg: 0x049 (Xilinx), part: 0x3636, ver: 0x1)
Warn : gdb services need one or more targets defined
setup.cfg loaded
tests.cfg loaded
lutram_do[0]: PASS
lutram_do[1]: PASS
lutram_do[2]: PASS
lutram_do[3]: PASS
lutram_do[4]: PASS
lutram_do[5]: PASS
lutram_do[6]: PASS
lutram_do[7]: PASS
shutdown command invoked
```

I can force a failure by writing to some address with a different value:

```
$ openocd -f digilent-hs2.cfg -f tests.cfg -c "read_lutram 0x0" \
                    -c "write_lutram 0x0 0x42" \
                    -c "print_test_result [test_RAM32M_init]" \
                    -c "shutdown"
Open On-Chip Debugger 0.12.0
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "jtag". To override use 'transport select <transport>'.
Info : clock speed 1 kHz
Info : JTAG tap: xc7.tap tap/device found: 0x13636093 (mfg: 0x049 (Xilinx), part: 0x3636, ver: 0x1)
Warn : gdb services need one or more targets defined
setup.cfg loaded
tests.cfg loaded
0x3c
0
port group 0: got 0x76543212 but expected 0x76543210
port group 1: got 0x89abcdec but expected 0x89abcdef
port group 2: got 0xf0ffffc but expected 0xf0fffff
port group 3: got 0x150bad1 but expected 0x150bad0
lutram_do[0]: FAIL
lutram_do[1]: FAIL
lutram_do[2]: FAIL
lutram_do[3]: FAIL
lutram_do[4]: FAIL
lutram_do[5]: FAIL
lutram_do[6]: FAIL
lutram_do[7]: FAIL
shutdown command invoked
```